### PR TITLE
Making sure we get the latest code from Kitura-Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,7 @@ matrix:
       sudo: required
 
 before_install:
-  - git submodule init
-  - git submodule update
-  - cd Kitura-Build && git checkout master && cd $TRAVIS_BUILD_DIR
+  - git submodule update --init --remote --merge --recursive
 
 script:
   - ./Kitura-Build/script_travis.sh $TRAVIS_OS_NAME $TRAVIS_BRANCH $TRAVIS_BUILD_DIR Kitura-CORS

--- a/Makefile
+++ b/Makefile
@@ -19,5 +19,4 @@ export KITURA_CI_BUILD_SCRIPTS_DIR=Kitura-Build/build
 
 Kitura-Build/build/Makefile:
 	@echo --- Fetching Kitura-Build submodule
-	git submodule init
-	git submodule update --remote --merge
+	git submodule update --init --remote --merge --recursive


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

To consolidate logic between travis files and Makefiles to get the latest code for master branch
## Motivation and Context

Updates to makefile were to guarantee that we get the latest master code when we do a make locally.  The changes to to the .travis.yml file were to simplify the before_script section.
## How Has This Been Tested?

Ran the code through Travis CI which builds Kitura on linux and mac.  Also ran a build locally
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
