### PR TITLE
IBM-Swift/Kitura#836 Switch out deprecated server.listen calls

### DIFF
--- a/Tests/KituraCORSTests/KituraTest.swift
+++ b/Tests/KituraCORSTests/KituraTest.swift
@@ -33,20 +33,24 @@ extension KituraTest {
     }
 
     func performServerTest(_ router: ServerDelegate, asyncTasks: @escaping (XCTestExpectation) -> Void...) {
-        let server = setupServer(port: 8090, delegate: router)
-        let requestQueue = DispatchQueue(label: "Request queue")
+        do {
+            let server = try HTTPServer.listen(on: 8090, delegate: router)
+            let requestQueue = DispatchQueue(label: "Request queue")
 
-        for (index, asyncTask) in asyncTasks.enumerated() {
-            let expectation = self.expectation(index)
-            requestQueue.async() {
-                asyncTask(expectation)
+            for (index, asyncTask) in asyncTasks.enumerated() {
+                let expectation = self.expectation(index)
+                requestQueue.async() {
+                    asyncTask(expectation)
+                }
             }
-        }
 
-        waitExpectation(timeout: 10) { error in
+            waitExpectation(timeout: 10) { error in
                 // blocks test until request completes
                 server.stop()
                 XCTAssertNil(error);
+            }
+        } catch {
+            XCTFail("Error: \(error)")
         }
     }
 
@@ -65,10 +69,6 @@ extension KituraTest {
             requestModifier(req)
         }
         req.end()
-    }
-
-    private func setupServer(port: Int, delegate: ServerDelegate) -> HTTPServer {
-        return HTTPServer.listen(port: port, delegate: delegate)
     }
 }
 


### PR DESCRIPTION
Switch out deprecated server.listen calls handling errors as needed
