### PR TITLE
Fix the issue with a single allowed origin

### DIFF
--- a/Sources/KituraCORS/CORS.swift
+++ b/Sources/KituraCORS/CORS.swift
@@ -96,8 +96,8 @@ public class CORS: RouterMiddleware {
             if set.contains(origin) {
                 allowed = true
             }
-        case .origin(let origin):
-            if origin == origin {
+        case .origin(let allowedOrigin):
+            if origin == allowedOrigin {
                 allowed = true
             }
         case .regex(let regex):


### PR DESCRIPTION
The current implementation always returns `true` which is not the expected behavior.