### PR TITLE
Update Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/IBM-Swift/Kitura.git", .upToNextMinor(from: "2.0.0")),
+        .package(url: "https://github.com/IBM-Swift/Kitura.git", .upToNextMinor(from: "2.1.0")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/KituraCORS/CORS.swift
+++ b/Sources/KituraCORS/CORS.swift
@@ -101,7 +101,7 @@ public class CORS: RouterMiddleware {
                 allowed = true
             }
         case .regex(let regex):
-            if regex.numberOfMatches(in: origin, options: [], range: NSRange(location: 0, length: origin.characters.count)) == 1 {
+            if regex.numberOfMatches(in: origin, options: [], range: NSRange(location: 0, length: origin.count)) == 1 {
                 allowed = true
             }
         default: break


### PR DESCRIPTION
Update Package.swift to break SPM infinite fetch-loop when using Kitura-CORS with Kitura 2.1.0. Resolves #32 
Remove compiler warning ('characters' is deprecated) in CORS.swift