### PR TITLE
Widen dependency on Kitura to next major

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/IBM-Swift/Kitura.git", .upToNextMinor(from: "2.1.0")),
+        .package(url: "https://github.com/IBM-Swift/Kitura.git", .upToNextMajor(from: "2.1.0")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
Kitura-CORS only relies not he middleware interface in Kitura so there shouldn't be any reason why it is tied to a specific minor level of Kitura.

Widening its dependency means its much less likely to cause version conflicts when people move up Kitura levels.